### PR TITLE
Error handling, code style, and using notices for command responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # Local cache files for testing
 /.cache
+config.yml
+.pre-commit-config.yaml

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
     // The party command is from the matrix-rust-sdk examples
     // Keeping it as an easter egg
     bot.register_text_command("party", None, |_, _, room| async move {
-        let content = RoomMessageEventContent::text_plain(".🎉🎊🥳 let's PARTY!! 🥳🎊🎉");
+        let content = RoomMessageEventContent::notice_plain(".🎉🎊🥳 let's PARTY!! 🥳🎊🎉");
         room.send(content).await.unwrap();
         Ok(())
     })
@@ -126,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
             let (context, _, _) = get_context(&room).await.unwrap();
             let mut context = add_role(&context);
             context.insert_str(0, ".context:\n");
-            let content = RoomMessageEventContent::text_plain(context);
+            let content = RoomMessageEventContent::notice_plain(context);
             room.send(content).await.unwrap();
             Ok(())
         },
@@ -159,7 +159,7 @@ async fn main() -> anyhow::Result<()> {
                     result.replace('\n', " ")
                 );
                 let result = format!(".response:\n{}", result);
-                let content = RoomMessageEventContent::text_plain(result);
+                let content = RoomMessageEventContent::notice_plain(result);
 
                 room.send(content).await.unwrap();
             }
@@ -182,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
         "clear",
         "Ignore all messages before this point".to_string(),
         |_, _, room| async move {
-            room.send(RoomMessageEventContent::text_plain(
+            room.send(RoomMessageEventContent::notice_plain(
                 ".clear: All messages before this will be ignored",
             ))
             .await
@@ -223,7 +223,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(stderr) => {
                     error!("Error: {}", stderr.replace('\n', " "));
-                    room.send(RoomMessageEventContent::text_plain(format!(
+                    room.send(RoomMessageEventContent::notice_plain(format!(
                         ".error: {}",
                         stderr.replace('\n', " ")
                     )))
@@ -298,7 +298,7 @@ async fn rate_limit(room: &Room, sender: &OwnedUserId) -> bool {
         *count
     };
     error!("User {} has sent {} messages", sender, count);
-    room.send(RoomMessageEventContent::text_plain(format!(
+    room.send(RoomMessageEventContent::notice_plain(format!(
         ".error: you have used up your message limit of {} messages.",
         message_limit
     )))
@@ -315,7 +315,7 @@ async fn list_models(_: OwnedUserId, _: String, room: Room) -> Result<(), ()> {
         current_model.unwrap_or(get_backend().default_model()),
         get_backend().list_models().join("\n")
     );
-    room.send(RoomMessageEventContent::text_plain(response))
+    room.send(RoomMessageEventContent::notice_plain(response))
         .await
         .unwrap();
     Ok(())
@@ -330,7 +330,7 @@ async fn model(sender: OwnedUserId, text: String, room: Room) -> Result<(), ()> 
         if models.contains(&model.to_string()) {
             // Set the model
             let response = format!(".model: Set to \"{}\"", model);
-            room.send(RoomMessageEventContent::text_plain(response))
+            room.send(RoomMessageEventContent::notice_plain(response))
                 .await
                 .unwrap();
         } else {
@@ -339,7 +339,7 @@ async fn model(sender: OwnedUserId, text: String, room: Room) -> Result<(), ()> 
                 model,
                 models.join("\n")
             );
-            room.send(RoomMessageEventContent::text_plain(response))
+            room.send(RoomMessageEventContent::notice_plain(response))
                 .await
                 .unwrap();
         }
@@ -378,7 +378,7 @@ async fn rename(sender: OwnedUserId, _: String, room: Room) -> Result<(), ()> {
             );
             let result = clean_summary_response(&result, None);
             if room.set_name(result).await.is_err() {
-                room.send(RoomMessageEventContent::text_plain(
+                room.send(RoomMessageEventContent::notice_plain(
                     ".error: I don't have permission to rename the room",
                 ))
                 .await
@@ -412,7 +412,7 @@ async fn rename(sender: OwnedUserId, _: String, room: Room) -> Result<(), ()> {
             );
             let result = clean_summary_response(&result, None);
             if room.set_room_topic(&result).await.is_err() {
-                room.send(RoomMessageEventContent::text_plain(
+                room.send(RoomMessageEventContent::notice_plain(
                     ".error: I don't have permission to set the topic",
                 ))
                 .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use regex::Regex;
 use serde::Deserialize;
 use std::format;
 use std::{collections::HashMap, fs::File, io::Read, path::PathBuf, sync::Mutex};
-use tracing::error;
+use tracing::{error, info};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -105,10 +105,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Syncs to the current state
     if let Err(e) = bot.sync().await {
-        error!("Error syncing: {e}");
+        info!("Error syncing: {e}");
     }
 
-    error!("The client is ready! Listening to new messages…");
+    info!("The client is ready! Listening to new messages…");
 
     // The party command is from the matrix-rust-sdk examples
     // Keeping it as an easter egg
@@ -145,7 +145,7 @@ async fn main() -> anyhow::Result<()> {
             // But we do need to read the context to figure out the model to use
             let (_, model, _) = get_context(&room).await.unwrap();
 
-            error!(
+            info!(
                 "Request: {} - {}",
                 sender.as_str(),
                 input.replace('\n', " ")
@@ -153,7 +153,7 @@ async fn main() -> anyhow::Result<()> {
             if let Ok(result) = get_backend().execute(&model, input.to_string(), Vec::new()) {
                 // Add the prefix ".response:\n" to the result
                 // That way we can identify our own responses and ignore them for context
-                error!(
+                info!(
                     "Response: {} - {}",
                     sender.as_str(),
                     result.replace('\n', " ")
@@ -209,13 +209,13 @@ async fn main() -> anyhow::Result<()> {
             // Append "ASSISTANT: " to the context string to indicate the assistant is speaking
             context.push_str("ASSISTANT: ");
 
-            error!(
+            info!(
                 "Request: {} - {}",
                 sender.as_str(),
                 context.replace('\n', " ")
             );
             if let Ok(result) = get_backend().execute(&model, context, media) {
-                error!(
+                info!(
                     "Response: {} - {}",
                     sender.as_str(),
                     result.replace('\n', " ")
@@ -366,14 +366,14 @@ async fn rename(sender: OwnedUserId, _: String, room: Room) -> Result<(), ()> {
                         ].join("");
         let model = get_chat_summary_model();
 
-        error!(
+        info!(
             "Request: {} - {}",
             sender.as_str(),
             title_prompt.replace('\n', " ")
         );
         let response = get_backend().execute(&model, title_prompt, Vec::new());
         if let Ok(result) = response {
-            error!(
+            info!(
                 "Response: {} - {}",
                 sender.as_str(),
                 result.replace('\n', " ")
@@ -400,14 +400,14 @@ async fn rename(sender: OwnedUserId, _: String, room: Room) -> Result<(), ()> {
         ]
         .join("");
 
-        error!(
+        info!(
             "Request: {} - {}",
             sender.as_str(),
             topic_prompt.replace('\n', " ")
         );
         let response = get_backend().execute(&model, topic_prompt, Vec::new());
         if let Ok(result) = response {
-            error!(
+            info!(
                 "Response: {} - {}",
                 sender.as_str(),
                 result.replace('\n', " ")


### PR DESCRIPTION
Notices are specifically intended for uses such as automated messages, so I made it send notices whenever the reply is not generated by the LLM.

Because AIChat is not properly using exit codes to indicate that something went wrong, I added a check for empty outputs. I would submit a fix to AIChat directly, but after repeated attempts at contributing to that project I've decided against wasting my time on that.

The misc refactors are more opinionated, but there are several reasons to prefer `match` over early returns:
- it's easier to follow the flow and branching of execution
- it makes adding new cases easier and leads to cleaner diffs
- (not applicable in this case, but) it enables totality checks

I couldn't think of a good way to replace the `break 'outer` with a more functional approach due to the intricacies of borrow handling and the convoluted logic involved, so I gave up on that one.