### PR TITLE
add option to disable media context

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ room_size_limit: 0 # Set a room size limit to respond in. 0 = Unlimited
 state_dir: "$XDG_STATE_HOME/chaz" # Optional, for setting the chaz state directory
 aichat_config_dir: "$AICHAT_CONFIG_DIR" # Optional, for using a separate aichat config
 chat_summary_model: "" # Optional, set a different model than the default to use for summarizing the chat
+disable_media_context: false # Optional, set to true to disable sending media context to aichat
 role: chaz # Optionally set a role, AKA system prompt. Set to `chaz` for the full chaz experience, or `cave-chaz` for even more chaz
 roles: # Optional, define your own roles
   - name: chaz # This one is predefined

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -36,6 +36,9 @@ username: ""
 # Optional. Set a room size limit to respond in. 0 = Unlimited
 #room_size_limit: 0
 
+# Optional. Set to false to disable sending media context to aichat
+#disable_media_context: false
+
 # Predefined roles here to use above
 # These roles are builtin and can be set by any user
 roles:

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -36,7 +36,7 @@ username: ""
 # Optional. Set a room size limit to respond in. 0 = Unlimited
 #room_size_limit: 0
 
-# Optional. Set to false to disable sending media context to aichat
+# Optional. Set to true to disable sending media context to aichat
 #disable_media_context: false
 
 # Predefined roles here to use above

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,8 @@ pub struct Config {
     role: Option<String>,
     /// Definitions of roles
     roles: Option<Vec<RoleDetails>>,
+    /// Disable sending media context to aichat
+    disable_media_context: Option<bool>,
 }
 
 lazy_static! {
@@ -493,6 +495,9 @@ async fn get_context(room: &Room) -> Result<(String, Option<String>, Vec<MediaFi
     let mut model_response = None;
     let mut media = Vec::new();
 
+    let config = GLOBAL_CONFIG.lock().unwrap().clone().unwrap();
+    let enable_media_context = !config.disable_media_context.unwrap_or(false);
+
     'outer: while let Ok(batch) = room.messages(options).await {
         // This assumes that the messages are in reverse order
         for message in batch.chunk {
@@ -509,26 +514,28 @@ async fn get_context(room: &Room) -> Result<(String, Option<String>, Vec<MediaFi
             {
                 match &content.msgtype {
                     MessageType::Image(image_content) => {
-                        let request = MediaRequest {
-                            source: image_content.source.clone(),
-                            format: MediaFormat::File,
-                        };
-                        let mime = image_content
-                            .info
-                            .as_ref()
-                            .unwrap()
-                            .mimetype
-                            .clone()
-                            .unwrap()
-                            .parse()
-                            .unwrap();
-                        let x = room
-                            .client()
-                            .media()
-                            .get_media_file(&request, None, &mime, true, None)
-                            .await
-                            .unwrap();
-                        media.insert(0, x);
+                        if enable_media_context {
+                            let request = MediaRequest {
+                                source: image_content.source.clone(),
+                                format: MediaFormat::File,
+                            };
+                            let mime = image_content
+                                .info
+                                .as_ref()
+                                .unwrap()
+                                .mimetype
+                                .clone()
+                                .unwrap()
+                                .parse()
+                                .unwrap();
+                            let x = room
+                                .client()
+                                .media()
+                                .get_media_file(&request, None, &mime, true, None)
+                                .await
+                                .unwrap();
+                            media.insert(0, x);
+                        }
                     }
                     MessageType::Text(text_content) => {
                         // Commands are always prefixed with a !, regardless of the name


### PR DESCRIPTION
Since I'm using ollama backend, aichat will throw an error saying "supports_vision: false" or something if you try to pass in media. I couldn't find a way to gracefully ignore it upstream. So add a config option to disable passing that.