### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1779130139,
-        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1779963685,
-        "narHash": "sha256-tUa/5UJCc3eaUqlCU8U/9dXefsgdq3sGQR4PKYrRHUw=",
+        "lastModified": 1782813643,
+        "narHash": "sha256-+Y7z6oWSTJSKIhxPw7YKHOcIgoX/1PWgpRMZMj4AHlw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e8a633e2794e74b3354cc8199ae53af649340036",
+        "rev": "df161b9bd5f8ff444b2c213cd45410b7da6da602",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake Input Update

Monthly `nix flake update` of Nix dependencies.

### Input Changes

- **crane**: [`edb3889` → `469fd08`](https://github.com/ipetkov/crane/compare/edb38893982a3338972bb4a2ec7ce7c29ba10fd9...469fd08d0bcf6926321fa973c6777fbc87785dd7)
- **fenix**: [`e8a633e` → `df161b9`](https://github.com/nix-community/fenix/compare/e8a633e2794e74b3354cc8199ae53af649340036...df161b9bd5f8ff444b2c213cd45410b7da6da602)
- **nixpkgs**: [`64c08a7` → `b5aa0fb`](https://github.com/nixos/nixpkgs/compare/64c08a7ca051951c8eae34e3e3cb1e202fe36786...b5aa0fbd538984f6e3d201be0005b4463d8b09f8)
- **treefmt-nix**: [`790751f` → `db94781`](https://github.com/numtide/treefmt-nix/compare/790751ff7fd3801feeaf96d7dc416a8d581265ba...db947814a175b7ca6ded66e21383d938df01c227)


<details>
<summary>nix flake update output</summary>

```
unpacking 'github:ipetkov/crane/469fd08d0bcf6926321fa973c6777fbc87785dd7' into the Git cache...
unpacking 'github:nix-community/fenix/df161b9bd5f8ff444b2c213cd45410b7da6da602' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb' into the Git cache...
unpacking 'github:nixos/nixpkgs/b5aa0fbd538984f6e3d201be0005b4463d8b09f8' into the Git cache...
unpacking 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227' into the Git cache...
warning: updating lock file "/home/runner/work/chaz/chaz/flake.lock":
• Updated input 'crane':
    'github:ipetkov/crane/edb3889' (2026-05-18)
  → 'github:ipetkov/crane/469fd08' (2026-06-18)
• Updated input 'fenix':
    'github:nix-community/fenix/e8a633e' (2026-05-28)
  → 'github:nix-community/fenix/df161b9' (2026-06-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/64c08a7' (2026-05-23)
  → 'github:nixos/nixpkgs/b5aa0fb' (2026-06-29)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/790751f' (2026-04-08)
  → 'github:numtide/treefmt-nix/db94781' (2026-05-31)
```

</details>

### Hold

This PR is on hold until **2026-07-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-07-08 -->