### PR TITLE
chore(deps): bump arcuru/actions reusable workflows to v0.2.1

### DIFF
--- a/.github/workflows/actions-update.yml
+++ b/.github/workflows/actions-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   actions-update:
-    uses: arcuru/actions/.github/workflows/actions-update.yml@31c804a9c15602300e5e292e80cac1ad5512a21a # v0.2.0
+    uses: arcuru/actions/.github/workflows/actions-update.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   cargo-update:
-    uses: arcuru/actions/.github/workflows/cargo-update.yml@31c804a9c15602300e5e292e80cac1ad5512a21a # v0.2.0
+    uses: arcuru/actions/.github/workflows/cargo-update.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/dependency-hold.yml
+++ b/.github/workflows/dependency-hold.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   hold:
-    uses: arcuru/actions/.github/workflows/dependency-hold.yml@31c804a9c15602300e5e292e80cac1ad5512a21a # v0.2.0
+    uses: arcuru/actions/.github/workflows/dependency-hold.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
     with:
       runs-on: ubicloud-standard-2

--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   flake-update:
-    uses: arcuru/actions/.github/workflows/flake-update.yml@31c804a9c15602300e5e292e80cac1ad5512a21a # v0.2.0
+    uses: arcuru/actions/.github/workflows/flake-update.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
     with:
       hold-days: ${{ inputs.hold_days || '7' }}
       runs-on: ubicloud-standard-2

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   audit:
-    uses: arcuru/actions/.github/workflows/security-audit.yml@31c804a9c15602300e5e292e80cac1ad5512a21a # v0.2.0
+    uses: arcuru/actions/.github/workflows/security-audit.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
     with:
       runs-on: ubicloud-standard-2
       enable-magic-cache: "false"

--- a/.github/workflows/update-hold.yml
+++ b/.github/workflows/update-hold.yml
@@ -15,6 +15,6 @@ permissions:
 
 jobs:
   update-hold:
-    uses: arcuru/actions/.github/workflows/update-hold.yml@31c804a9c15602300e5e292e80cac1ad5512a21a # v0.2.0
+    uses: arcuru/actions/.github/workflows/update-hold.yml@c8144123ad5a2c6316b7becab8233b68dfa637d9 # v0.2.1
     with:
       runs-on: ubicloud-standard-2


### PR DESCRIPTION
Bumps the pinned `arcuru/actions` reusable-workflow refs from v0.2.0 (v0.1.0 for pokem) to **v0.2.1**.

v0.2.1 fixes the dependency-hold gate: the reusable workflow now grants `pull-requests: read` for its PR-label query. At v0.2.0 the reusable's own `permissions:` block was `contents: read` only, which set `pull-requests` to `none` regardless of the (already correct) caller ceiling, so the gate failed with `gh: Resource not accessible by integration (HTTP 403)` on every `deps/` PR.

This PR is on a non-`deps/` branch so the hold gate passes (it exits early for non-dependency branches) and doesn't self-block.

Assisted-by: Claude Opus 4.8 (root-cause analysis, code generation)