### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1779130139,
-        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "lastModified": 1785541369,
+        "narHash": "sha256-6VCYI5xashcnAR1lambqt9FGh0F6kYhg1P2Z0VDlr48=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "rev": "508ff4829aefddee8ea62291e86b144b58365724",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1779963685,
-        "narHash": "sha256-tUa/5UJCc3eaUqlCU8U/9dXefsgdq3sGQR4PKYrRHUw=",
+        "lastModified": 1785488171,
+        "narHash": "sha256-v1ylO7biFcQ0K/hipStpTeItaPQ7XdspNdWAWPVX9S0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e8a633e2794e74b3354cc8199ae53af649340036",
+        "rev": "080d4837db213b64169eb497a97a665773b9225c",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1785454630,
+        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake Input Update

Monthly `nix flake update` of Nix dependencies.

### Input Changes

- **crane**: [`edb3889` → `508ff48`](https://github.com/ipetkov/crane/compare/edb38893982a3338972bb4a2ec7ce7c29ba10fd9...508ff4829aefddee8ea62291e86b144b58365724)
- **fenix**: [`e8a633e` → `080d483`](https://github.com/nix-community/fenix/compare/e8a633e2794e74b3354cc8199ae53af649340036...080d4837db213b64169eb497a97a665773b9225c)
- **flake-parts**: [`f7c1a2d` → `17c9d6c`](https://github.com/hercules-ci/flake-parts/compare/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb...17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e)
- **nixpkgs**: [`64c08a7` → `1559d3d`](https://github.com/nixos/nixpkgs/compare/64c08a7ca051951c8eae34e3e3cb1e202fe36786...1559d3daa3ecc813a650b79375ea61b6741b8746)
- **treefmt-nix**: [`790751f` → `d1187f8`](https://github.com/numtide/treefmt-nix/compare/790751ff7fd3801feeaf96d7dc416a8d581265ba...d1187f8bc71fb8aab02395869ec3f5c1920f75c0)


<details>
<summary>nix flake update output</summary>

```
unpacking 'github:ipetkov/crane/508ff4829aefddee8ea62291e86b144b58365724' into the Git cache...
unpacking 'github:nix-community/fenix/080d4837db213b64169eb497a97a665773b9225c' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' into the Git cache...
unpacking 'github:nixos/nixpkgs/1559d3daa3ecc813a650b79375ea61b6741b8746' into the Git cache...
unpacking 'github:numtide/treefmt-nix/d1187f8bc71fb8aab02395869ec3f5c1920f75c0' into the Git cache...
warning: updating lock file "/home/runner/work/chaz/chaz/flake.lock":
• Updated input 'crane':
    'github:ipetkov/crane/edb3889' (2026-05-18)
  → 'github:ipetkov/crane/508ff48' (2026-07-31)
• Updated input 'fenix':
    'github:nix-community/fenix/e8a633e' (2026-05-28)
  → 'github:nix-community/fenix/080d483' (2026-07-31)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6c' (2026-07-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/64c08a7' (2026-05-23)
  → 'github:nixos/nixpkgs/1559d3d' (2026-07-30)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/790751f' (2026-04-08)
  → 'github:numtide/treefmt-nix/d1187f8' (2026-07-29)
```

</details>

### Hold

This PR is on hold until **2026-08-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-08-08 -->