### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1779130139,
-        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1780999471,
-        "narHash": "sha256-rY4yNlSzDY3OoYBdgjwlpVKWY/oUeOb65709i/tJbns=",
+        "lastModified": 1788193191,
+        "narHash": "sha256-ml05aPtgKYo2+XvL66tRmym5I2YK4UVjBpTGhkvOYew=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "db976d430cbb6b0d6b300b4e22cbb28462841af2",
+        "rev": "c9d23506b787a5f5bad51b50231738127761f4c5",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Flake Input Update

Monthly `nix flake update` of Nix dependencies.

### Input Changes

- **crane**: [`edb3889` → `692f7e9`](https://github.com/ipetkov/crane/compare/edb38893982a3338972bb4a2ec7ce7c29ba10fd9...692f7e9ef2ece8125b466f66f2af532b3edaed0d)
- **fenix**: [`db976d4` → `c9d2350`](https://github.com/nix-community/fenix/compare/db976d430cbb6b0d6b300b4e22cbb28462841af2...c9d23506b787a5f5bad51b50231738127761f4c5)
- **flake-parts**: [`f7c1a2d` → `9d0d871`](https://github.com/hercules-ci/flake-parts/compare/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb...9d0d87172c374f89da73c1cfe6d81ae62feac1f1)
- **nixpkgs**: [`64c08a7` → `34ab990`](https://github.com/nixos/nixpkgs/compare/64c08a7ca051951c8eae34e3e3cb1e202fe36786...34ab99075ac4f7e40cf037eef32cb1c360bb85e9)
- **treefmt-nix**: [`790751f` → `27b3b12`](https://github.com/numtide/treefmt-nix/compare/790751ff7fd3801feeaf96d7dc416a8d581265ba...27b3b12a8e6375f28ebe122f07d230ca5459bbfa)


<details>
<summary>nix flake update output</summary>

```
unpacking 'github:ipetkov/crane/692f7e9ef2ece8125b466f66f2af532b3edaed0d' into the Git cache...
unpacking 'github:nix-community/fenix/c9d23506b787a5f5bad51b50231738127761f4c5' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/9d0d87172c374f89da73c1cfe6d81ae62feac1f1' into the Git cache...
unpacking 'github:nixos/nixpkgs/34ab99075ac4f7e40cf037eef32cb1c360bb85e9' into the Git cache...
unpacking 'github:numtide/treefmt-nix/27b3b12a8e6375f28ebe122f07d230ca5459bbfa' into the Git cache...
warning: updating lock file "/home/runner/work/chaz/chaz/flake.lock":
• Updated input 'crane':
    'github:ipetkov/crane/edb3889' (2026-05-18)
  → 'github:ipetkov/crane/692f7e9' (2026-08-21)
• Updated input 'fenix':
    'github:nix-community/fenix/db976d4' (2026-06-09)
  → 'github:nix-community/fenix/c9d2350' (2026-08-31)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d' (2026-05-13)
  → 'github:hercules-ci/flake-parts/9d0d871' (2026-08-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/64c08a7' (2026-05-23)
  → 'github:nixos/nixpkgs/34ab990' (2026-08-31)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/790751f' (2026-04-08)
  → 'github:numtide/treefmt-nix/27b3b12' (2026-08-16)
```

</details>

### Hold

This PR is on hold until **2026-09-08** (7-day waiting period).
The `on-hold` label will be automatically removed after the hold expires.

<!-- hold-until: 2026-09-08 -->